### PR TITLE
210822 Quality Control (for Belarus2019 and Chad2019) JW

### DIFF
--- a/06_Prepare_MICS6_01_Batch_final.do
+++ b/06_Prepare_MICS6_01_Batch_final.do
@@ -595,7 +595,7 @@ clear
         label var gl_adm1_code "Global Administrative Unit Layers(GAUL) Code"
 		label var gl_adm0_code "Global Administrative Unit Layers(GAUL) Country Code"
 		
-	rename (c_del_eff1 c_del_eff1_q c_del_eff2 c_del_eff2_q w_unmet c_measles_vacc c_mateduc ind_sampleweight mor_wdob mor_doi)(c_sba_eff1 c_sba_eff1_q c_sba_eff2 c_sba_eff2_q w_unmet_fp c_measles w_mateduc w_sampleweight hm_dob hm_doi)
+	rename (c_del_eff1 c_del_eff1_q c_del_eff2 c_del_eff2_q w_unmet c_measles_vacc c_mateduc ind_sampleweight mor_wdob mor_doi)(c_sba_eff1 c_sba_eff1_q c_sba_eff2 c_sba_eff2_q w_unmet_fp c_measles c_mateduc w_sampleweight hm_dob hm_doi)
 
 	* Drop observations with missings on all outcomes
 		// missings dropvars c_* w_* , force

--- a/06_Prepare_MICS6_01_Batch_final.do
+++ b/06_Prepare_MICS6_01_Batch_final.do
@@ -503,13 +503,13 @@ clear
 		label var c_illtreat "Child: 0-4 with diarrhea, rapid breathing and/or fever in L2W seen by formal healthcare provider"
 		label var c_stunted "Child: 0-4y HfA <-2 std.dev. from median (WHO) (1/0)"
 		label var c_stunted_sev "Child: 0-4y HfA <-3 std.dev. from median (WHO) (1/0)"
-		label var c_haz "Child: 0-4y HfA std.dev. from median (WHO)"
+		label var c_hfa "Child: 0-4y HfA std.dev. from median (WHO)"
 		label var c_underweight "Child: 0-4y WfA <-2 std.dev. from median (WHO) (1/0)"
 		label var c_underweight_sev "Child: 0-4y WfA <-3 std.dev. from median (WHO) (1/0)"
-		label var c_waz "Child: 0-4y WfA std.dev. from median (WHO)"
+		label var c_wfa "Child: 0-4y WfA std.dev. from median (WHO)"
 		label var c_wasted "Child: 0-4y WfH <-2 std.dev. from median (WHO) (1/0)"
 		label var c_wasted_sev "Child: 0-4y WfH <-3 std.dev. from median (WHO) (1/0)"
-		label var c_whz "Child: 0-4y WfH std.dev. from median (WHO)"	
+		label var c_wfh "Child: 0-4y WfH std.dev. from median (WHO)"	
 		label var c_height "Child:  0-4y height in cm"
 		label var c_weight "Child: 0-4y weight in kg"
 		label var c_treatARI "Child: 0-4y with ARI in L2W seen by formal provider (1/0)"
@@ -595,7 +595,7 @@ clear
         label var gl_adm1_code "Global Administrative Unit Layers(GAUL) Code"
 		label var gl_adm0_code "Global Administrative Unit Layers(GAUL) Country Code"
 		
-	rename (c_del_eff1 c_del_eff1_q c_del_eff2 c_del_eff2_q w_unmet c_measles_vacc c_mateduc ind_sampleweight mor_wdob mor_doi)(c_sba_eff1 c_sba_eff1_q c_sba_eff2 c_sba_eff2_q w_unmet_fp c_measles c_mateduc w_sampleweight hm_dob hm_doi)
+	rename (c_del_eff1 c_del_eff1_q c_del_eff2 c_del_eff2_q w_unmet c_measles_vacc c_mateduc ind_sampleweight mor_wdob mor_doi)(c_sba_eff1 c_sba_eff1_q c_sba_eff2 c_sba_eff2_q w_unmet_fp c_measles w_mateduc w_sampleweight hm_dob hm_doi)
 
 	* Drop observations with missings on all outcomes
 		// missings dropvars c_* w_* , force
@@ -603,6 +603,12 @@ clear
 	* Save micro-dataset
 	 
 	saveold "${OUT}/ADePT READY/MICS/New/MICS6-`name'Adept.dta", replace
+
+***********************************
+*****      Quality Control       **
+***********************************	
+	do "${root}/STATA/DO/SC/06_Prepare_MICS/06_Prepare_MICS6/Quality_control.do" 
+	save "${INTER}/Indicator_`name'.dta", replace 
 			
 }		
 

--- a/MICS6_do_c_anthro.do
+++ b/MICS6_do_c_anthro.do
@@ -6,13 +6,13 @@
 if inlist(country_name,"Belarus2019") {
 	gen c_height = .
 	gen c_weight = .
-	gen c_haz = .
+	gen c_hfa = .
 	gen c_stunted = .
 	gen c_stunted_sev = .
-	gen c_waz = .
+	gen c_wfa = .
 	gen c_underweight = .
 	gen c_underweight_sev = .
-	gen c_whz = .
+	gen c_wfh = .
 	gen c_wasted = .
 	gen c_wasted_sev = .
 }
@@ -34,6 +34,7 @@ if ~inlist(country_name,"Belarus2019") {
 		replace c_stunted = haz2 < -2						// stunted if child is more than 2 SDs below HAZ reference
 		replace c_stunted_sev = haz2 < -3					// severly stunted if child is more than 3 SDs below HAZ reference
 		for var c_stunted c_stunted_sev c_haz: replace X = . if inlist(hazflag,.,1)		// missing if height or age flagged
+		rename c_haz c_hfa
 	
 
 *c_underweight: Child under 5 underweight
@@ -44,6 +45,7 @@ if ~inlist(country_name,"Belarus2019") {
 		replace c_underweight = waz2 < -2					// stunted if child is more than 2 SDs below WAZ reference
 		replace c_underweight_sev = waz2 < -3					// severly stunted if child is more than 3 SDs below WAZ reference
 		for var c_underweight c_underweight_sev c_waz: replace X = . if inlist(wazflag,.,1)	// missing if weight or age flagged
+		rename c_waz c_wfa
 
 *c_wasted: Child under 5 wasted
 		gen c_whz = .
@@ -53,4 +55,5 @@ if ~inlist(country_name,"Belarus2019") {
 		replace c_wasted = whz2 < -2						// stunted if child is more than 2 SDs below WAZ reference
 		replace c_wasted_sev = whz2 < -3						// stunted if child is more than 2 SDs below WAZ reference
 		for var c_wasted c_wasted_sev c_whz: replace X = . if inlist(whzflag,.,1)	// missing if weight or age flagged
+		rename c_whz c_wfh
 }

--- a/Quality_control.do
+++ b/Quality_control.do
@@ -42,7 +42,7 @@
     }
 	
 	***for variables generated from 11_child_other
-	foreach var of var w_mateduc c_ITN{
+	foreach var of var c_mateduc c_ITN{
 	egen pop_`var' = wtmean(`var'),weight(hh_sampleweight)
 	}
 	


### PR DESCRIPTION
- rename child anthro variables to match with the variable name in the quality control do file

Based on the raw data of Belarus2019 and Chad2019, I adjusted the codes to make sure that as many indicators as possible can be generated smoothly. 
Besides, could you please tell me which folder in the OneDrive should I upload the indicator file to?