### PR TITLE
Debug for wrong grammar in template

### DIFF
--- a/MICS6_Master.do
+++ b/MICS6_Master.do
@@ -250,7 +250,7 @@ foreach name in $newMICS6countries {
 ***********************************	
 	mmerge hh1 hh2 using "${SOURCE}/MICS/MICS6-`name'/MICS6-`name'hh.dta"
 	
-	if _merge == 2
+	drop if _merge == 2
 	drop _merge
 	gen country_name = "`name'"
 	if inlist("`name'","Nepal2019") {


### PR DESCRIPTION
I guess in a branch the code was accidentally mistakenly changed. I am fixing it and validated by comparing it to the previous branch that worked fine. Please see if this work fine on your end too @robin-wang